### PR TITLE
Small improvements in task handlers and in pushing kernel-netlink.conf

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,8 +5,10 @@
   service:
     name=apparmor
     state=restarted
+  become: True
 
 - name: restart strongswan
   service:
     name=strongswan
     state=restarted
+  become: True

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -9,7 +9,7 @@
 - name: Configure kernel-netlink settings
   template:
     src: kernel-netlink.conf.j2
-    dest: /etc/strongswan.d/charon/kernel-netlink.conf
+    dest: "{{strongswan_netlink_conf_base}}/charon/kernel-netlink.conf"
     mode: 0750
   notify:
     restart strongswan

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -2,3 +2,4 @@
 # Debian-specific vars file for strongswan
 
 strongswan_config_base: /etc
+strongswan_netlink_conf_base: "{{strongswan_config_base}}/strongswan.d"

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -2,3 +2,4 @@
 # Redhat-specific vars file for strongswan
 
 strongswan_config_base: /etc/strongswan
+strongswan_netlink_conf_base: "{{strongswan_config_base}}"


### PR DESCRIPTION
Added "become: True" for task handlers.
I have found that without "become: True" the task handlers return error. The error appears even if the ansible-role-strongswan used with "become: True".

Changed path for kernel-netlink.conf file for Debian. Debian expects kernel-netlink.conf here: "/etc/strongswan.d/charon/kernel-netlink.conf ".