### PR TITLE
IKEv1 support

### DIFF
--- a/templates/connection.secrets.j2
+++ b/templates/connection.secrets.j2
@@ -3,7 +3,11 @@
 {% set authby = item.0.conn.authby if item.0.conn.authby is defined else strongswan_conn_default.authby %}
 # conn {{ item.0.name }} ({{ item.0.left.address }} <-> {{ item.0.right.address }})
 {% if authby == 'psk' or authby == 'secret' %}
+{%   if item.0.conn.keyexchange|lower == 'ikev1' %}
+{{ item.0.left.address }} {{ item.0.right.address }} : PSK "{{ item.0.secret }}"
+{%   else %}
 {{ item.0.left.id }} {{ item.0.right.id }} : PSK {{ item.0.secret }}
+{%   endif %}
 {% elif authby == 'rsasig' or authby == 'ecdsasig' %}
 {{ item.0.left.id }} {{ item.0.right.id }} : {{ item.0.secret }}
 {% endif %}


### PR DESCRIPTION
If IKEv1 is set as key exchange then the id must not be set in the connection settings. In the secrets map the ip address must be used instead.

See: https://wiki.strongswan.org/projects/strongswan/wiki/IpsecSecrets#ID-selectors (second paragraph)